### PR TITLE
Ww/game turns

### DIFF
--- a/src/Components/ChatComponents/ChatContainer/ChatContainer.tsx
+++ b/src/Components/ChatComponents/ChatContainer/ChatContainer.tsx
@@ -3,6 +3,7 @@ import MessageContainer from '../MessageContainer/MessageContainer';
 import InputBox from '../InputBox/InputBox';
 import { Flex } from '@chakra-ui/react';
 import { ChatFeed, WebSocketSend } from '../../../types';
+import { useColorMode } from '@chakra-ui/react';
 
 const ChatContainer: React.FC<{
   send: WebSocketSend | undefined;
@@ -10,9 +11,10 @@ const ChatContainer: React.FC<{
   userId?: string;
   userName?: string;
 }> = ({ send, chatFeed, userId }) => {
+  const { colorMode } = useColorMode();
   return (
     <Flex
-      bg={'purple.900'}
+      bg={colorMode === 'light' ? 'purple.100' : 'purple.900'}
       direction={'column'}
       justify={'space-between'}
       data-testid={'chat-container-test'}

--- a/src/Routes/Game.tsx
+++ b/src/Routes/Game.tsx
@@ -67,9 +67,6 @@ export const Game = () => {
   return (
     <Box>
       <Box textAlign="center" fontSize="xl">
-        {/* needs to go in a header */}
-        {/* <ColorModeSwitcher justifySelf="flex-end" /> */}
-
         <Grid
           templateAreas={`"header header"
                   "game chat"
@@ -81,12 +78,15 @@ export const Game = () => {
           padding={'5px'}
         >
           <GridItem pl="2" area={'header'}>
-            <Flex direction={'row'} justify={'flex-end'}>
+            <Flex direction={'row'} justify={'space-between'}>
+              <ColorModeSwitcher />
               {user?.username}
             </Flex>
           </GridItem>
           <GridItem pl="2" area={'game'}>
-            <GameBoard userId={user?.id} send={send} gameState={gameState} />
+            {isReady && user && (
+              <GameBoard userId={user.id} send={send} gameState={gameState} />
+            )}
           </GridItem>
           <GridItem pl="2" area={'chat'}>
             <ChatContainer

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -26,6 +26,8 @@ export interface ScoreboardProps {
 export interface GameInstance {
   players?: Player[];
   currentCardsOnTable: TableCard[];
+  dealer: number;
+  isStart: boolean;
   currentPlayer: number;
   picker: string;
   secretTeam: string[];

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,5 @@
+import { Player } from '../types';
+
+export function getPlayerIndex(players?: Player[], playerId?: string) {
+  return players?.map((p: Player) => p.id).indexOf(playerId || '');
+}


### PR DESCRIPTION
[connected with this pr](https://github.com/willybeans/sheepshead-api-ts/pull/14)

adding a header with some different state's depending on if the player is:

 - not seated , ie: spectating 
<img width="614" alt="Screenshot 2023-10-23 at 8 32 47 PM" src="https://github.com/willybeans/sheeps-head-cra/assets/20260208/bf6fa38e-a02a-4a53-b468-f556eda0c388">

 - seated and it is the initial turn, so they must decide to pick blind cards or pass
<img width="603" alt="Screenshot 2023-10-23 at 8 34 05 PM" src="https://github.com/willybeans/sheeps-head-cra/assets/20260208/a4265d1b-c1ff-4971-9e33-6c8915ae125d">

 - seated and it is / isnt their turn to play a card 
<img width="603" alt="Screenshot 2023-10-23 at 8 34 27 PM" src="https://github.com/willybeans/sheeps-head-cra/assets/20260208/0fbb87a8-110f-469f-a627-c36b524db8e1">


<img width="637" alt="Screenshot 2023-10-23 at 8 59 23 PM" src="https://github.com/willybeans/sheeps-head-cra/assets/20260208/bcc52be6-5f0d-4681-8df6-a2b447d899a5">




